### PR TITLE
Change all timestamps to unix epochs

### DIFF
--- a/postgres/sql/create_tables.sql
+++ b/postgres/sql/create_tables.sql
@@ -51,7 +51,8 @@ CREATE TABLE IF NOT EXISTS Employee (
 CREATE TABLE IF NOT EXISTS CompanyHistory (
   company_id varchar(250) REFERENCES Company(company_id) ON UPDATE CASCADE ON DELETE CASCADE,
   time_fetched BIGINT NOT NULL,
-  trading_price MONEY NOT NULL
+  trading_price MONEY NOT NULL,
+  num_shares INT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS Manages (

--- a/postgres/sql/create_tables.sql
+++ b/postgres/sql/create_tables.sql
@@ -14,12 +14,12 @@ CREATE TABLE IF NOT EXISTS Account (
 CREATE TABLE IF NOT EXISTS LoginSession (
   token BYTEA PRIMARY KEY,
   user_id INT REFERENCES Account (user_id) ON UPDATE CASCADE ON DELETE CASCADE,
-  time_created TIMESTAMP 
+  time_created BIGINT 
 );
 
 CREATE TABLE IF NOT EXISTS PaymentHistory (
   user_id INT REFERENCES Account (user_id) ON UPDATE CASCADE ON DELETE CASCADE,
-  time_created TIMESTAMP NOT NULL,
+  time_created BIGINT NOT NULL,
   amount_invested INT NOT NULL
 );
 
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS Company (
 CREATE TABLE IF NOT EXISTS Transactions (
   company_id varchar(250) REFERENCES Company(company_id) ON UPDATE CASCADE ON DELETE CASCADE,
   user_id INT REFERENCES Account (user_id) ON UPDATE CASCADE ON DELETE CASCADE,
-  time_executed TIMESTAMP NOT NULL,
+  time_executed BIGINT NOT NULL,
   num_shares INT NOT NULL,
   buy_or_sell BOOLEAN NOT NULL
 );
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS Employee (
 
 CREATE TABLE IF NOT EXISTS CompanyHistory (
   company_id varchar(250) REFERENCES Company(company_id) ON UPDATE CASCADE ON DELETE CASCADE,
-  time_fetched INT NOT NULL,
+  time_fetched BIGINT NOT NULL,
   trading_price MONEY NOT NULL
 );
 
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS FundInfo (
 );
 
 CREATE TABLE IF NOT EXISTS FundPerformance (
-  ts TIMESTAMP NOT NULL,
+  ts BIGINT NOT NULL,
   fund_value MONEY NOT NULL,
   fund_invested MONEY NOT NULL
 );

--- a/postgres/sql/create_tables.sql
+++ b/postgres/sql/create_tables.sql
@@ -51,8 +51,7 @@ CREATE TABLE IF NOT EXISTS Employee (
 CREATE TABLE IF NOT EXISTS CompanyHistory (
   company_id varchar(250) REFERENCES Company(company_id) ON UPDATE CASCADE ON DELETE CASCADE,
   time_fetched DECIMAL NOT NULL,
-  trading_price MONEY NOT NULL,
-  num_shares INT NOT NULL
+  trading_price MONEY NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS Manages (

--- a/postgres/sql/create_tables.sql
+++ b/postgres/sql/create_tables.sql
@@ -14,12 +14,12 @@ CREATE TABLE IF NOT EXISTS Account (
 CREATE TABLE IF NOT EXISTS LoginSession (
   token BYTEA PRIMARY KEY,
   user_id INT REFERENCES Account (user_id) ON UPDATE CASCADE ON DELETE CASCADE,
-  time_created BIGINT 
+  time_created DECIMAL 
 );
 
 CREATE TABLE IF NOT EXISTS PaymentHistory (
   user_id INT REFERENCES Account (user_id) ON UPDATE CASCADE ON DELETE CASCADE,
-  time_created BIGINT NOT NULL,
+  time_created DECIMAL NOT NULL,
   amount_invested INT NOT NULL
 );
 
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS Company (
 CREATE TABLE IF NOT EXISTS Transactions (
   company_id varchar(250) REFERENCES Company(company_id) ON UPDATE CASCADE ON DELETE CASCADE,
   user_id INT REFERENCES Account (user_id) ON UPDATE CASCADE ON DELETE CASCADE,
-  time_executed BIGINT NOT NULL,
+  time_executed DECIMAL NOT NULL,
   num_shares INT NOT NULL,
   buy_or_sell BOOLEAN NOT NULL
 );
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS Employee (
 
 CREATE TABLE IF NOT EXISTS CompanyHistory (
   company_id varchar(250) REFERENCES Company(company_id) ON UPDATE CASCADE ON DELETE CASCADE,
-  time_fetched BIGINT NOT NULL,
+  time_fetched DECIMAL NOT NULL,
   trading_price MONEY NOT NULL,
   num_shares INT NOT NULL
 );
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS FundInfo (
 );
 
 CREATE TABLE IF NOT EXISTS FundPerformance (
-  ts BIGINT NOT NULL,
+  ts DECIMAL NOT NULL,
   fund_value MONEY NOT NULL,
   fund_invested MONEY NOT NULL
 );

--- a/postgres/sql/fill_tables.sql
+++ b/postgres/sql/fill_tables.sql
@@ -24,4 +24,4 @@ VALUES ('Vanguard 500',
 
 -- Creates fund history --
 INSERT INTO FundPerformance (ts, fund_value, fund_invested)
-VALUES (CURRENT_DATE, 0, 0);
+VALUES (extract(epoch from now()), 0, 0);

--- a/server/auth/crypto.py
+++ b/server/auth/crypto.py
@@ -1,10 +1,9 @@
 import secrets
 import bcrypt
-from datetime import timedelta
+from datetime import timedelta, datetime
 from sqlalchemy.orm import Session
 from functools import wraps
 from database.schema import Loginsession
-from datetime import datetime
 
 
 def encode_password(password: str):
@@ -22,7 +21,7 @@ def generate_auth_cookie(resp, user_id: str, session: Session):
     token = secrets.token_hex(32).encode("utf-8")
 
     new_login_session = Loginsession(
-        user_id=user_id, token=token, time_created=datetime.now()
+        user_id=user_id, token=token, time_created=datetime.now().timestamp()
     )
     session.add(new_login_session)
     session.commit()

--- a/server/database/schema.py
+++ b/server/database/schema.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 from sqlalchemy import (
-    BigInteger,
     Boolean,
     Column,
     ForeignKey,
     Integer,
     LargeBinary,
+    Numeric,
     String,
     Table,
     text,
@@ -80,7 +80,7 @@ class Fundinfo(Base):
 t_fundperformance = Table(
     "fundperformance",
     metadata,
-    Column("ts", BigInteger, nullable=False),
+    Column("ts", Numeric, nullable=False),
     Column("fund_value", MONEY, nullable=False),
     Column("fund_invested", MONEY, nullable=False),
 )
@@ -93,8 +93,9 @@ t_companyhistory = Table(
         "company_id",
         ForeignKey("company.company_id", ondelete="CASCADE", onupdate="CASCADE"),
     ),
-    Column("time_fetched", BigInteger, nullable=False),
+    Column("time_fetched", Numeric, nullable=False),
     Column("trading_price", MONEY, nullable=False),
+    Column("num_shares", Integer, nullable=False),
 )
 
 
@@ -105,7 +106,7 @@ class Loginsession(Base):
     user_id = Column(
         ForeignKey("account.user_id", ondelete="CASCADE", onupdate="CASCADE")
     )
-    time_created = Column(BigInteger)
+    time_created = Column(Numeric)
 
     user = relationship("Account")
 
@@ -130,7 +131,7 @@ t_paymenthistory = Table(
     Column(
         "user_id", ForeignKey("account.user_id", ondelete="CASCADE", onupdate="CASCADE")
     ),
-    Column("time_created", BigInteger, nullable=False),
+    Column("time_created", Numeric, nullable=False),
     Column("amount_invested", Integer, nullable=False),
 )
 
@@ -145,7 +146,7 @@ t_transactions = Table(
     Column(
         "user_id", ForeignKey("account.user_id", ondelete="CASCADE", onupdate="CASCADE")
     ),
-    Column("time_executed", BigInteger, nullable=False),
+    Column("time_executed", Numeric, nullable=False),
     Column("num_shares", Integer, nullable=False),
     Column("buy_or_sell", Boolean, nullable=False),
 )

--- a/server/database/schema.py
+++ b/server/database/schema.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     Column,
-    DateTime,
     ForeignKey,
     Integer,
     LargeBinary,
@@ -80,7 +80,7 @@ class Fundinfo(Base):
 t_fundperformance = Table(
     "fundperformance",
     metadata,
-    Column("ts", DateTime, nullable=False),
+    Column("ts", BigInteger, nullable=False),
     Column("fund_value", MONEY, nullable=False),
     Column("fund_invested", MONEY, nullable=False),
 )
@@ -93,7 +93,7 @@ t_companyhistory = Table(
         "company_id",
         ForeignKey("company.company_id", ondelete="CASCADE", onupdate="CASCADE"),
     ),
-    Column("time_fetched", Integer, nullable=False),
+    Column("time_fetched", BigInteger, nullable=False),
     Column("trading_price", MONEY, nullable=False),
 )
 
@@ -105,7 +105,7 @@ class Loginsession(Base):
     user_id = Column(
         ForeignKey("account.user_id", ondelete="CASCADE", onupdate="CASCADE")
     )
-    time_created = Column(DateTime)
+    time_created = Column(BigInteger)
 
     user = relationship("Account")
 
@@ -130,7 +130,7 @@ t_paymenthistory = Table(
     Column(
         "user_id", ForeignKey("account.user_id", ondelete="CASCADE", onupdate="CASCADE")
     ),
-    Column("time_created", DateTime, nullable=False),
+    Column("time_created", BigInteger, nullable=False),
     Column("amount_invested", Integer, nullable=False),
 )
 
@@ -145,7 +145,7 @@ t_transactions = Table(
     Column(
         "user_id", ForeignKey("account.user_id", ondelete="CASCADE", onupdate="CASCADE")
     ),
-    Column("time_executed", DateTime, nullable=False),
+    Column("time_executed", BigInteger, nullable=False),
     Column("num_shares", Integer, nullable=False),
     Column("buy_or_sell", Boolean, nullable=False),
 )


### PR DESCRIPTION
Changed every reference in the DB to a timestamp to a BIGINT epoch. That way, we can more easily compare times between tables. 

Updated the schema to reflect the new database changes

Updated timestamp to insert epoch instead of datetime

**Note:** Datetime library in python can easily convert between datetime and epoch